### PR TITLE
Solved the problem with DLL load on Windows with Python >=3.8.

### DIFF
--- a/py3nj/__init__.py
+++ b/py3nj/__init__.py
@@ -7,6 +7,7 @@ extra_dll_dir = os.path.join(os.path.dirname(__file__), ".libs")
 if sys.platform == "win32" and os.path.isdir(extra_dll_dir):
     os.environ.setdefault("PATH", "")
     os.environ["PATH"] += os.pathsep + extra_dll_dir
+    os.add_dll_directory(extra_dll_dir)
 
 from ._version import __version__
 


### PR DESCRIPTION
DLLs are only loaded from trusted locations on Windows with Python 3.8 and higher (as described [here](https://stackoverflow.com/questions/41365446/how-to-resolve-importerror-dll-load-failed-on-python)), which resulted in an `ImportError: DLL load failed while importing _wigner` in the previous version of __init__.py.

Adding .lib to the DLL directories solves the problem with loading the DLL files.