### PR TITLE
Publish ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
                 fetch-depth: 0
                 submodules: true
         
-          - uses: pypa/cibuildwheel@v2.15
+          - uses: pypa/cibuildwheel@v2.14
         
           - name: Upload wheels
             uses: actions/upload-artifact@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,4 +43,18 @@ jobs:
             uses: actions/upload-artifact@v3
             with:
                 path: wheelhouse/*.whl
-              
+
+    upload_all:
+        needs: [build_wheels, make_sdist]
+        environment: pypi
+        permissions:
+            id-token: write
+        runs-on: ubuntu-latest
+        if: github.event_name == 'release' && github.event.action == 'published'
+        steps:
+          - uses: actions/download-artifact@v3
+            with:
+                name: artifact
+                path: dist
+        
+          - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adding a CI to publish wheels to PyPI, according to the comment https://github.com/fujiisoup/py3nj/pull/27#issuecomment-1694585707